### PR TITLE
fixed generic lib/* wildcards that globs subfolders

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,10 @@ setup(name = "matta",
     package_data = {
         'matta' : [
             'LICENSE',
-            'libs/*',
-            'libs/leaflet-0.7.3/*',
+            'libs/*.js',
+            'libs/*.css',
+            'libs/leaflet-0.7.3/*.js',
+            'libs/leaflet-0.7.3/*.css',
             'libs/leaflet-0.7.3/images/*',
             'templates/base.html',
             'templates/base.js',


### PR DESCRIPTION
Would cause libs/leaflet-0.7.3 not to be found during installation